### PR TITLE
Travis CI should also run the actual build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os:
+  - linux
+  - osx
+  - windows
 language: rust
 rust:
   - stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ before_script:
   - rustup component add clippy-preview
 script:
   - cargo clippy -- -D warnings
+  - cargo build --release


### PR DESCRIPTION
Also adds build targets for Windows and MacOS, to ensure no compatibility breaks.

In the future some tests should be added.